### PR TITLE
添加微软双拼缺少的韵母ve到t和v键

### DIFF
--- a/src/utils/spconfig.json
+++ b/src/utils/spconfig.json
@@ -182,7 +182,7 @@
       "w/ia,ua/w",
       "e/e/",
       "r/er,uan/r",
-      "t/ue/t",
+      "t/ue,ve/t",
       "y/v,uai/y",
       "u/u/sh",
       "i/i/ch",
@@ -201,7 +201,7 @@
       "z/ei/z",
       "x/ie/x",
       "c/iao/c",
-      "v/ui/zh",
+      "v/ui,ve/zh",
       "b/ou/b",
       "n/in/n",
       "m/ian/m"


### PR DESCRIPTION
缺少韵母ve导致某些字无法打出，在此将缺少的韵母添加到t和v键（微软双拼的ve通过t和v都可以打出）